### PR TITLE
removed the period from the abbreviation of Dutch months. Officially it ...

### DIFF
--- a/angular-locale_nl-aw.js
+++ b/angular-locale_nl-aw.js
@@ -67,18 +67,18 @@ $provide.value("$locale", {
       "za"
     ],
     "SHORTMONTH": [
-      "jan.",
-      "feb.",
-      "mrt.",
-      "apr.",
+      "jan",
+      "feb",
+      "mrt",
+      "apr",
       "mei",
-      "jun.",
-      "jul.",
-      "aug.",
-      "sep.",
-      "okt.",
-      "nov.",
-      "dec."
+      "jun",
+      "jul",
+      "aug",
+      "sep",
+      "okt",
+      "nov",
+      "dec"
     ],
     "WEEKENDRANGE": [
       5,

--- a/angular-locale_nl-be.js
+++ b/angular-locale_nl-be.js
@@ -67,18 +67,18 @@ $provide.value("$locale", {
       "za"
     ],
     "SHORTMONTH": [
-      "jan.",
-      "feb.",
-      "mrt.",
-      "apr.",
+      "jan",
+      "feb",
+      "mrt",
+      "apr",
       "mei",
-      "jun.",
-      "jul.",
-      "aug.",
-      "sep.",
-      "okt.",
-      "nov.",
-      "dec."
+      "jun",
+      "jul",
+      "aug",
+      "sep",
+      "okt",
+      "nov",
+      "dec"
     ],
     "WEEKENDRANGE": [
       5,

--- a/angular-locale_nl-bq.js
+++ b/angular-locale_nl-bq.js
@@ -67,18 +67,18 @@ $provide.value("$locale", {
       "za"
     ],
     "SHORTMONTH": [
-      "jan.",
-      "feb.",
-      "mrt.",
-      "apr.",
+      "jan",
+      "feb",
+      "mrt",
+      "apr",
       "mei",
-      "jun.",
-      "jul.",
-      "aug.",
-      "sep.",
-      "okt.",
-      "nov.",
-      "dec."
+      "jun",
+      "jul",
+      "aug",
+      "sep",
+      "okt",
+      "nov",
+      "dec"
     ],
     "WEEKENDRANGE": [
       5,

--- a/angular-locale_nl-cw.js
+++ b/angular-locale_nl-cw.js
@@ -67,18 +67,18 @@ $provide.value("$locale", {
       "za"
     ],
     "SHORTMONTH": [
-      "jan.",
-      "feb.",
-      "mrt.",
-      "apr.",
+      "jan",
+      "feb",
+      "mrt",
+      "apr",
       "mei",
-      "jun.",
-      "jul.",
-      "aug.",
-      "sep.",
-      "okt.",
-      "nov.",
-      "dec."
+      "jun",
+      "jul",
+      "aug",
+      "sep",
+      "okt",
+      "nov",
+      "dec"
     ],
     "WEEKENDRANGE": [
       5,

--- a/angular-locale_nl-nl.js
+++ b/angular-locale_nl-nl.js
@@ -67,18 +67,18 @@ $provide.value("$locale", {
       "za"
     ],
     "SHORTMONTH": [
-      "jan.",
-      "feb.",
-      "mrt.",
-      "apr.",
+      "jan",
+      "feb",
+      "mrt",
+      "apr",
       "mei",
-      "jun.",
-      "jul.",
-      "aug.",
-      "sep.",
-      "okt.",
-      "nov.",
-      "dec."
+      "jun",
+      "jul",
+      "aug",
+      "sep",
+      "okt",
+      "nov",
+      "dec"
     ],
     "WEEKENDRANGE": [
       5,

--- a/angular-locale_nl-sr.js
+++ b/angular-locale_nl-sr.js
@@ -67,18 +67,18 @@ $provide.value("$locale", {
       "za"
     ],
     "SHORTMONTH": [
-      "jan.",
-      "feb.",
-      "mrt.",
-      "apr.",
+      "jan",
+      "feb",
+      "mrt",
+      "apr",
       "mei",
-      "jun.",
-      "jul.",
-      "aug.",
-      "sep.",
-      "okt.",
-      "nov.",
-      "dec."
+      "jun",
+      "jul",
+      "aug",
+      "sep",
+      "okt",
+      "nov",
+      "dec"
     ],
     "WEEKENDRANGE": [
       5,

--- a/angular-locale_nl-sx.js
+++ b/angular-locale_nl-sx.js
@@ -67,18 +67,18 @@ $provide.value("$locale", {
       "za"
     ],
     "SHORTMONTH": [
-      "jan.",
-      "feb.",
-      "mrt.",
-      "apr.",
+      "jan",
+      "feb",
+      "mrt",
+      "apr",
       "mei",
-      "jun.",
-      "jul.",
-      "aug.",
-      "sep.",
-      "okt.",
-      "nov.",
-      "dec."
+      "jun",
+      "jul",
+      "aug",
+      "sep",
+      "okt",
+      "nov",
+      "dec"
     ],
     "WEEKENDRANGE": [
       5,


### PR DESCRIPTION
...can be abbreviated with or without the period, so having the period removed from the source seems a better option. See also (in Dutch) http://taaladvies.net/taal/advies/vraag/1727/afkortingen_van_de_namen_van_de_maanden/