### PR TITLE
Changed negative currency value from "€ 5,00 -" to "- € 5,00"

### DIFF
--- a/angular-locale_nl-nl.js
+++ b/angular-locale_nl-nl.js
@@ -115,8 +115,8 @@ $provide.value("$locale", {
         "maxFrac": 2,
         "minFrac": 2,
         "minInt": 1,
-        "negPre": "\u00a4\u00a0",
-        "negSuf": "-",
+        "negPre": "-\u00a0\u00a4\u00a0",
+        "negSuf": "",
         "posPre": "\u00a4\u00a0",
         "posSuf": ""
       }


### PR DESCRIPTION
Changed the formatting of negative currency values in the nl-nl locale.
We use "- € 5,00" instead of "€ 5,00 -"

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/bower-angular-i18n/16)

<!-- Reviewable:end -->
