### PR TITLE
es_MX, Fixing mediumDate to match original format 

### DIFF
--- a/angular-locale_es-mx.js
+++ b/angular-locale_es-mx.js
@@ -69,7 +69,7 @@ $provide.value("$locale", {
     "fullDate": "EEEE, d 'de' MMMM 'de' y",
     "longDate": "d 'de' MMMM 'de' y",
     "medium": "dd/MM/y h:mm:ss a",
-    "mediumDate": "dd/MM/y",
+    "mediumDate": "dd/MMM/y",
     "mediumTime": "h:mm:ss a",
     "short": "dd/MM/yy h:mm a",
     "shortDate": "dd/MM/yy",


### PR DESCRIPTION
The original format uses MMM:
'mediumDate': equivalent to 'MMM d, y' for en_US locale (e.g. Sep 3, 2010)
