### PR TITLE
Months and days codes in Spanish are misspelled

### DIFF
--- a/angular-locale_es-419.js
+++ b/angular-locale_es-419.js
@@ -51,7 +51,7 @@ $provide.value("$locale", {
     "SHORTMONTH": [
       "ene",
       "feb",
-      "mar.",
+      "mar",
       "abr",
       "may",
       "jun",

--- a/angular-locale_es-419.js
+++ b/angular-locale_es-419.js
@@ -40,27 +40,27 @@ $provide.value("$locale", {
       "diciembre"
     ],
     "SHORTDAY": [
-      "dom.",
-      "lun.",
-      "mar.",
-      "mi\u00e9.",
-      "jue.",
-      "vie.",
-      "s\u00e1b."
+      "dom",
+      "lun",
+      "mar",
+      "mi\u00e9",
+      "jue",
+      "vie",
+      "s\u00e1b"
     ],
     "SHORTMONTH": [
-      "ene.",
-      "feb.",
+      "ene",
+      "feb",
       "mar.",
-      "abr.",
-      "may.",
-      "jun.",
-      "jul.",
-      "ago.",
-      "sept.",
-      "oct.",
-      "nov.",
-      "dic."
+      "abr",
+      "may",
+      "jun",
+      "jul",
+      "ago",
+      "sep",
+      "oct",
+      "nov",
+      "dic"
     ],
     "STANDALONEMONTH": [
       "Enero",

--- a/angular-locale_es-ar.js
+++ b/angular-locale_es-ar.js
@@ -51,7 +51,7 @@ $provide.value("$locale", {
     "SHORTMONTH": [
       "ene",
       "feb",
-      "mar.",
+      "mar",
       "abr",
       "may",
       "jun",

--- a/angular-locale_es-ar.js
+++ b/angular-locale_es-ar.js
@@ -40,27 +40,27 @@ $provide.value("$locale", {
       "diciembre"
     ],
     "SHORTDAY": [
-      "dom.",
-      "lun.",
-      "mar.",
-      "mi\u00e9.",
-      "jue.",
-      "vie.",
-      "s\u00e1b."
+      "dom",
+      "lun",
+      "mar",
+      "mi\u00e9",
+      "jue",
+      "vie",
+      "s\u00e1b"
     ],
     "SHORTMONTH": [
-      "ene.",
-      "feb.",
+      "ene",
+      "feb",
       "mar.",
-      "abr.",
-      "may.",
-      "jun.",
-      "jul.",
-      "ago.",
-      "sept.",
-      "oct.",
-      "nov.",
-      "dic."
+      "abr",
+      "may",
+      "jun",
+      "jul",
+      "ago",
+      "sep",
+      "oct",
+      "nov",
+      "dic"
     ],
     "STANDALONEMONTH": [
       "Enero",

--- a/angular-locale_es-bo.js
+++ b/angular-locale_es-bo.js
@@ -51,7 +51,7 @@ $provide.value("$locale", {
     "SHORTMONTH": [
       "ene",
       "feb",
-      "mar.",
+      "mar",
       "abr",
       "may",
       "jun",

--- a/angular-locale_es-bo.js
+++ b/angular-locale_es-bo.js
@@ -40,27 +40,27 @@ $provide.value("$locale", {
       "diciembre"
     ],
     "SHORTDAY": [
-      "dom.",
-      "lun.",
-      "mar.",
-      "mi\u00e9.",
-      "jue.",
-      "vie.",
-      "s\u00e1b."
+      "dom",
+      "lun",
+      "mar",
+      "mi\u00e9",
+      "jue",
+      "vie",
+      "s\u00e1b"
     ],
     "SHORTMONTH": [
-      "ene.",
-      "feb.",
+      "ene",
+      "feb",
       "mar.",
-      "abr.",
-      "may.",
-      "jun.",
-      "jul.",
-      "ago.",
-      "sept.",
-      "oct.",
-      "nov.",
-      "dic."
+      "abr",
+      "may",
+      "jun",
+      "jul",
+      "ago",
+      "sep",
+      "oct",
+      "nov",
+      "dic"
     ],
     "STANDALONEMONTH": [
       "Enero",

--- a/angular-locale_es-cl.js
+++ b/angular-locale_es-cl.js
@@ -51,7 +51,7 @@ $provide.value("$locale", {
     "SHORTMONTH": [
       "ene",
       "feb",
-      "mar.",
+      "mar",
       "abr",
       "may",
       "jun",

--- a/angular-locale_es-cl.js
+++ b/angular-locale_es-cl.js
@@ -40,27 +40,27 @@ $provide.value("$locale", {
       "diciembre"
     ],
     "SHORTDAY": [
-      "dom.",
-      "lun.",
-      "mar.",
-      "mi\u00e9.",
-      "jue.",
-      "vie.",
-      "s\u00e1b."
+      "dom",
+      "lun",
+      "mar",
+      "mi\u00e9",
+      "jue",
+      "vie",
+      "s\u00e1b"
     ],
     "SHORTMONTH": [
-      "ene.",
-      "feb.",
+      "ene",
+      "feb",
       "mar.",
-      "abr.",
-      "may.",
-      "jun.",
-      "jul.",
-      "ago.",
-      "sept.",
-      "oct.",
-      "nov.",
-      "dic."
+      "abr",
+      "may",
+      "jun",
+      "jul",
+      "ago",
+      "sep",
+      "oct",
+      "nov",
+      "dic"
     ],
     "STANDALONEMONTH": [
       "Enero",

--- a/angular-locale_es-co.js
+++ b/angular-locale_es-co.js
@@ -51,7 +51,7 @@ $provide.value("$locale", {
     "SHORTMONTH": [
       "ene",
       "feb",
-      "mar.",
+      "mar",
       "abr",
       "may",
       "jun",

--- a/angular-locale_es-co.js
+++ b/angular-locale_es-co.js
@@ -40,27 +40,27 @@ $provide.value("$locale", {
       "diciembre"
     ],
     "SHORTDAY": [
-      "dom.",
-      "lun.",
-      "mar.",
-      "mi\u00e9.",
-      "jue.",
-      "vie.",
-      "s\u00e1b."
+      "dom",
+      "lun",
+      "mar",
+      "mi\u00e9",
+      "jue",
+      "vie",
+      "s\u00e1b"
     ],
     "SHORTMONTH": [
-      "ene.",
-      "feb.",
+      "ene",
+      "feb",
       "mar.",
-      "abr.",
-      "may.",
-      "jun.",
-      "jul.",
-      "ago.",
-      "sept.",
-      "oct.",
-      "nov.",
-      "dic."
+      "abr",
+      "may",
+      "jun",
+      "jul",
+      "ago",
+      "sep",
+      "oct",
+      "nov",
+      "dic"
     ],
     "STANDALONEMONTH": [
       "Enero",

--- a/angular-locale_es-cr.js
+++ b/angular-locale_es-cr.js
@@ -51,7 +51,7 @@ $provide.value("$locale", {
     "SHORTMONTH": [
       "ene",
       "feb",
-      "mar.",
+      "mar",
       "abr",
       "may",
       "jun",

--- a/angular-locale_es-cr.js
+++ b/angular-locale_es-cr.js
@@ -40,27 +40,27 @@ $provide.value("$locale", {
       "diciembre"
     ],
     "SHORTDAY": [
-      "dom.",
-      "lun.",
-      "mar.",
-      "mi\u00e9.",
-      "jue.",
-      "vie.",
-      "s\u00e1b."
+      "dom",
+      "lun",
+      "mar",
+      "mi\u00e9",
+      "jue",
+      "vie",
+      "s\u00e1b"
     ],
     "SHORTMONTH": [
-      "ene.",
-      "feb.",
+      "ene",
+      "feb",
       "mar.",
-      "abr.",
-      "may.",
-      "jun.",
-      "jul.",
-      "ago.",
-      "sept.",
-      "oct.",
-      "nov.",
-      "dic."
+      "abr",
+      "may",
+      "jun",
+      "jul",
+      "ago",
+      "sep",
+      "oct",
+      "nov",
+      "dic"
     ],
     "STANDALONEMONTH": [
       "Enero",

--- a/angular-locale_es-cu.js
+++ b/angular-locale_es-cu.js
@@ -51,7 +51,7 @@ $provide.value("$locale", {
     "SHORTMONTH": [
       "ene",
       "feb",
-      "mar.",
+      "mar",
       "abr",
       "may",
       "jun",

--- a/angular-locale_es-cu.js
+++ b/angular-locale_es-cu.js
@@ -40,27 +40,27 @@ $provide.value("$locale", {
       "diciembre"
     ],
     "SHORTDAY": [
-      "dom.",
-      "lun.",
-      "mar.",
-      "mi\u00e9.",
-      "jue.",
-      "vie.",
-      "s\u00e1b."
+      "dom",
+      "lun",
+      "mar",
+      "mi\u00e9",
+      "jue",
+      "vie",
+      "s\u00e1b"
     ],
     "SHORTMONTH": [
-      "ene.",
-      "feb.",
+      "ene",
+      "feb",
       "mar.",
-      "abr.",
-      "may.",
-      "jun.",
-      "jul.",
-      "ago.",
-      "sept.",
-      "oct.",
-      "nov.",
-      "dic."
+      "abr",
+      "may",
+      "jun",
+      "jul",
+      "ago",
+      "sep",
+      "oct",
+      "nov",
+      "dic"
     ],
     "STANDALONEMONTH": [
       "Enero",

--- a/angular-locale_es-do.js
+++ b/angular-locale_es-do.js
@@ -51,7 +51,7 @@ $provide.value("$locale", {
     "SHORTMONTH": [
       "ene",
       "feb",
-      "mar.",
+      "mar",
       "abr",
       "may",
       "jun",

--- a/angular-locale_es-do.js
+++ b/angular-locale_es-do.js
@@ -40,27 +40,27 @@ $provide.value("$locale", {
       "diciembre"
     ],
     "SHORTDAY": [
-      "dom.",
-      "lun.",
-      "mar.",
-      "mi\u00e9.",
-      "jue.",
-      "vie.",
-      "s\u00e1b."
+      "dom",
+      "lun",
+      "mar",
+      "mi\u00e9",
+      "jue",
+      "vie",
+      "s\u00e1b"
     ],
     "SHORTMONTH": [
-      "ene.",
-      "feb.",
+      "ene",
+      "feb",
       "mar.",
-      "abr.",
-      "may.",
-      "jun.",
-      "jul.",
-      "ago.",
-      "sept.",
-      "oct.",
-      "nov.",
-      "dic."
+      "abr",
+      "may",
+      "jun",
+      "jul",
+      "ago",
+      "sep",
+      "oct",
+      "nov",
+      "dic"
     ],
     "STANDALONEMONTH": [
       "Enero",

--- a/angular-locale_es-ea.js
+++ b/angular-locale_es-ea.js
@@ -51,7 +51,7 @@ $provide.value("$locale", {
     "SHORTMONTH": [
       "ene",
       "feb",
-      "mar.",
+      "mar",
       "abr",
       "may",
       "jun",

--- a/angular-locale_es-ea.js
+++ b/angular-locale_es-ea.js
@@ -40,27 +40,27 @@ $provide.value("$locale", {
       "diciembre"
     ],
     "SHORTDAY": [
-      "dom.",
-      "lun.",
-      "mar.",
-      "mi\u00e9.",
-      "jue.",
-      "vie.",
-      "s\u00e1b."
+      "dom",
+      "lun",
+      "mar",
+      "mi\u00e9",
+      "jue",
+      "vie",
+      "s\u00e1b"
     ],
     "SHORTMONTH": [
-      "ene.",
-      "feb.",
+      "ene",
+      "feb",
       "mar.",
-      "abr.",
-      "may.",
-      "jun.",
-      "jul.",
-      "ago.",
-      "sept.",
-      "oct.",
-      "nov.",
-      "dic."
+      "abr",
+      "may",
+      "jun",
+      "jul",
+      "ago",
+      "sep",
+      "oct",
+      "nov",
+      "dic"
     ],
     "STANDALONEMONTH": [
       "Enero",

--- a/angular-locale_es-ec.js
+++ b/angular-locale_es-ec.js
@@ -51,7 +51,7 @@ $provide.value("$locale", {
     "SHORTMONTH": [
       "ene",
       "feb",
-      "mar.",
+      "mar",
       "abr",
       "may",
       "jun",

--- a/angular-locale_es-ec.js
+++ b/angular-locale_es-ec.js
@@ -40,27 +40,27 @@ $provide.value("$locale", {
       "diciembre"
     ],
     "SHORTDAY": [
-      "dom.",
-      "lun.",
-      "mar.",
-      "mi\u00e9.",
-      "jue.",
-      "vie.",
-      "s\u00e1b."
+      "dom",
+      "lun",
+      "mar",
+      "mi\u00e9",
+      "jue",
+      "vie",
+      "s\u00e1b"
     ],
     "SHORTMONTH": [
-      "ene.",
-      "feb.",
+      "ene",
+      "feb",
       "mar.",
-      "abr.",
-      "may.",
-      "jun.",
-      "jul.",
-      "ago.",
-      "sept.",
-      "oct.",
-      "nov.",
-      "dic."
+      "abr",
+      "may",
+      "jun",
+      "jul",
+      "ago",
+      "sep",
+      "oct",
+      "nov",
+      "dic"
     ],
     "STANDALONEMONTH": [
       "Enero",

--- a/angular-locale_es-es.js
+++ b/angular-locale_es-es.js
@@ -40,27 +40,27 @@ $provide.value("$locale", {
       "diciembre"
     ],
     "SHORTDAY": [
-      "dom.",
-      "lun.",
-      "mar.",
-      "mi\u00e9.",
-      "jue.",
-      "vie.",
-      "s\u00e1b."
+      "dom",
+      "lun",
+      "mar",
+      "mi\u00e9",
+      "jue",
+      "vie",
+      "s\u00e1b"
     ],
     "SHORTMONTH": [
-      "ene.",
-      "feb.",
-      "mar.",
-      "abr.",
-      "may.",
-      "jun.",
-      "jul.",
-      "ago.",
-      "sept.",
-      "oct.",
-      "nov.",
-      "dic."
+      "ene",
+      "feb",
+      "mar",
+      "abr",
+      "may",
+      "jun",
+      "jul",
+      "ago",
+      "sep",
+      "oct",
+      "nov",
+      "dic"
     ],
     "STANDALONEMONTH": [
       "Enero",

--- a/angular-locale_es-gq.js
+++ b/angular-locale_es-gq.js
@@ -40,27 +40,27 @@ $provide.value("$locale", {
       "diciembre"
     ],
     "SHORTDAY": [
-      "dom.",
-      "lun.",
-      "mar.",
-      "mi\u00e9.",
-      "jue.",
-      "vie.",
-      "s\u00e1b."
+      "dom",
+      "lun",
+      "mar",
+      "mi\u00e9",
+      "jue",
+      "vie",
+      "s\u00e1b"
     ],
     "SHORTMONTH": [
-      "ene.",
-      "feb.",
-      "mar.",
-      "abr.",
-      "may.",
-      "jun.",
-      "jul.",
-      "ago.",
-      "sept.",
-      "oct.",
-      "nov.",
-      "dic."
+      "ene",
+      "feb",
+      "mar",
+      "abr",
+      "may",
+      "jun",
+      "jul",
+      "ago",
+      "sept",
+      "oct",
+      "nov",
+      "dic"
     ],
     "STANDALONEMONTH": [
       "Enero",

--- a/angular-locale_es-gt.js
+++ b/angular-locale_es-gt.js
@@ -51,7 +51,7 @@ $provide.value("$locale", {
     "SHORTMONTH": [
       "ene",
       "feb",
-      "mar.",
+      "mar",
       "abr",
       "may",
       "jun",

--- a/angular-locale_es-gt.js
+++ b/angular-locale_es-gt.js
@@ -40,27 +40,27 @@ $provide.value("$locale", {
       "diciembre"
     ],
     "SHORTDAY": [
-      "dom.",
-      "lun.",
-      "mar.",
-      "mi\u00e9.",
-      "jue.",
-      "vie.",
-      "s\u00e1b."
+      "dom",
+      "lun",
+      "mar",
+      "mi\u00e9",
+      "jue",
+      "vie",
+      "s\u00e1b"
     ],
     "SHORTMONTH": [
-      "ene.",
-      "feb.",
+      "ene",
+      "feb",
       "mar.",
-      "abr.",
-      "may.",
-      "jun.",
-      "jul.",
-      "ago.",
-      "sept.",
-      "oct.",
-      "nov.",
-      "dic."
+      "abr",
+      "may",
+      "jun",
+      "jul",
+      "ago",
+      "sep",
+      "oct",
+      "nov",
+      "dic"
     ],
     "STANDALONEMONTH": [
       "Enero",

--- a/angular-locale_es-hn.js
+++ b/angular-locale_es-hn.js
@@ -51,7 +51,7 @@ $provide.value("$locale", {
     "SHORTMONTH": [
       "ene",
       "feb",
-      "mar.",
+      "mar",
       "abr",
       "may",
       "jun",

--- a/angular-locale_es-hn.js
+++ b/angular-locale_es-hn.js
@@ -40,27 +40,27 @@ $provide.value("$locale", {
       "diciembre"
     ],
     "SHORTDAY": [
-      "dom.",
-      "lun.",
-      "mar.",
-      "mi\u00e9.",
-      "jue.",
-      "vie.",
-      "s\u00e1b."
+      "dom",
+      "lun",
+      "mar",
+      "mi\u00e9",
+      "jue",
+      "vie",
+      "s\u00e1b"
     ],
     "SHORTMONTH": [
-      "ene.",
-      "feb.",
+      "ene",
+      "feb",
       "mar.",
-      "abr.",
-      "may.",
-      "jun.",
-      "jul.",
-      "ago.",
-      "sept.",
-      "oct.",
-      "nov.",
-      "dic."
+      "abr",
+      "may",
+      "jun",
+      "jul",
+      "ago",
+      "sep",
+      "oct",
+      "nov",
+      "dic"
     ],
     "STANDALONEMONTH": [
       "Enero",

--- a/angular-locale_es-ic.js
+++ b/angular-locale_es-ic.js
@@ -51,7 +51,7 @@ $provide.value("$locale", {
     "SHORTMONTH": [
       "ene",
       "feb",
-      "mar.",
+      "mar",
       "abr",
       "may",
       "jun",

--- a/angular-locale_es-ic.js
+++ b/angular-locale_es-ic.js
@@ -40,27 +40,27 @@ $provide.value("$locale", {
       "diciembre"
     ],
     "SHORTDAY": [
-      "dom.",
-      "lun.",
-      "mar.",
-      "mi\u00e9.",
-      "jue.",
-      "vie.",
-      "s\u00e1b."
+      "dom",
+      "lun",
+      "mar",
+      "mi\u00e9",
+      "jue",
+      "vie",
+      "s\u00e1b"
     ],
     "SHORTMONTH": [
-      "ene.",
-      "feb.",
+      "ene",
+      "feb",
       "mar.",
-      "abr.",
-      "may.",
-      "jun.",
-      "jul.",
-      "ago.",
-      "sept.",
-      "oct.",
-      "nov.",
-      "dic."
+      "abr",
+      "may",
+      "jun",
+      "jul",
+      "ago",
+      "sep",
+      "oct",
+      "nov",
+      "dic"
     ],
     "STANDALONEMONTH": [
       "Enero",

--- a/angular-locale_es-mx.js
+++ b/angular-locale_es-mx.js
@@ -40,18 +40,18 @@ $provide.value("$locale", {
       "diciembre"
     ],
     "SHORTDAY": [
-      "dom.",
-      "lun.",
-      "mar.",
-      "mi\u00e9.",
-      "jue.",
-      "vie.",
-      "s\u00e1b."
+      "dom",
+      "lun",
+      "mar",
+      "mi\u00e9",
+      "jue",
+      "vie",
+      "s\u00e1b"
     ],
     "SHORTMONTH": [
       "ene",
       "feb",
-      "mar",
+      "mar.",
       "abr",
       "may",
       "jun",

--- a/angular-locale_es-mx.js
+++ b/angular-locale_es-mx.js
@@ -51,7 +51,7 @@ $provide.value("$locale", {
     "SHORTMONTH": [
       "ene",
       "feb",
-      "mar.",
+      "mar",
       "abr",
       "may",
       "jun",

--- a/angular-locale_es-ni.js
+++ b/angular-locale_es-ni.js
@@ -51,7 +51,7 @@ $provide.value("$locale", {
     "SHORTMONTH": [
       "ene",
       "feb",
-      "mar.",
+      "mar",
       "abr",
       "may",
       "jun",

--- a/angular-locale_es-ni.js
+++ b/angular-locale_es-ni.js
@@ -40,27 +40,27 @@ $provide.value("$locale", {
       "diciembre"
     ],
     "SHORTDAY": [
-      "dom.",
-      "lun.",
-      "mar.",
-      "mi\u00e9.",
-      "jue.",
-      "vie.",
-      "s\u00e1b."
+      "dom",
+      "lun",
+      "mar",
+      "mi\u00e9",
+      "jue",
+      "vie",
+      "s\u00e1b"
     ],
     "SHORTMONTH": [
-      "ene.",
-      "feb.",
+      "ene",
+      "feb",
       "mar.",
-      "abr.",
-      "may.",
-      "jun.",
-      "jul.",
-      "ago.",
-      "sept.",
-      "oct.",
-      "nov.",
-      "dic."
+      "abr",
+      "may",
+      "jun",
+      "jul",
+      "ago",
+      "sep",
+      "oct",
+      "nov",
+      "dic"
     ],
     "STANDALONEMONTH": [
       "Enero",

--- a/angular-locale_es-pa.js
+++ b/angular-locale_es-pa.js
@@ -51,7 +51,7 @@ $provide.value("$locale", {
     "SHORTMONTH": [
       "ene",
       "feb",
-      "mar.",
+      "mar",
       "abr",
       "may",
       "jun",

--- a/angular-locale_es-pa.js
+++ b/angular-locale_es-pa.js
@@ -40,27 +40,27 @@ $provide.value("$locale", {
       "diciembre"
     ],
     "SHORTDAY": [
-      "dom.",
-      "lun.",
-      "mar.",
-      "mi\u00e9.",
-      "jue.",
-      "vie.",
-      "s\u00e1b."
+      "dom",
+      "lun",
+      "mar",
+      "mi\u00e9",
+      "jue",
+      "vie",
+      "s\u00e1b"
     ],
     "SHORTMONTH": [
-      "ene.",
-      "feb.",
+      "ene",
+      "feb",
       "mar.",
-      "abr.",
-      "may.",
-      "jun.",
-      "jul.",
-      "ago.",
-      "sept.",
-      "oct.",
-      "nov.",
-      "dic."
+      "abr",
+      "may",
+      "jun",
+      "jul",
+      "ago",
+      "sep",
+      "oct",
+      "nov",
+      "dic"
     ],
     "STANDALONEMONTH": [
       "Enero",

--- a/angular-locale_es-pe.js
+++ b/angular-locale_es-pe.js
@@ -40,27 +40,27 @@ $provide.value("$locale", {
       "diciembre"
     ],
     "SHORTDAY": [
-      "dom.",
-      "lun.",
-      "mar.",
-      "mi\u00e9.",
-      "jue.",
-      "vie.",
-      "s\u00e1b."
+      "dom",
+      "lun",
+      "mar",
+      "mi\u00e9",
+      "jue",
+      "vie",
+      "s\u00e1b"
     ],
     "SHORTMONTH": [
-      "ene.",
-      "feb.",
+      "ene",
+      "feb",
       "mar.",
-      "abr.",
-      "may.",
-      "jun.",
-      "jul.",
-      "ago.",
-      "set.",
-      "oct.",
-      "nov.",
-      "dic."
+      "abr",
+      "may",
+      "jun",
+      "jul",
+      "ago",
+      "sep",
+      "oct",
+      "nov",
+      "dic"
     ],
     "STANDALONEMONTH": [
       "Enero",

--- a/angular-locale_es-pe.js
+++ b/angular-locale_es-pe.js
@@ -51,7 +51,7 @@ $provide.value("$locale", {
     "SHORTMONTH": [
       "ene",
       "feb",
-      "mar.",
+      "mar",
       "abr",
       "may",
       "jun",

--- a/angular-locale_es-ph.js
+++ b/angular-locale_es-ph.js
@@ -51,7 +51,7 @@ $provide.value("$locale", {
     "SHORTMONTH": [
       "ene",
       "feb",
-      "mar.",
+      "mar",
       "abr",
       "may",
       "jun",

--- a/angular-locale_es-ph.js
+++ b/angular-locale_es-ph.js
@@ -40,27 +40,27 @@ $provide.value("$locale", {
       "diciembre"
     ],
     "SHORTDAY": [
-      "dom.",
-      "lun.",
-      "mar.",
-      "mi\u00e9.",
-      "jue.",
-      "vie.",
-      "s\u00e1b."
+      "dom",
+      "lun",
+      "mar",
+      "mi\u00e9",
+      "jue",
+      "vie",
+      "s\u00e1b"
     ],
     "SHORTMONTH": [
-      "ene.",
-      "feb.",
+      "ene",
+      "feb",
       "mar.",
-      "abr.",
-      "may.",
-      "jun.",
-      "jul.",
-      "ago.",
-      "sept.",
-      "oct.",
-      "nov.",
-      "dic."
+      "abr",
+      "may",
+      "jun",
+      "jul",
+      "ago",
+      "sep",
+      "oct",
+      "nov",
+      "dic"
     ],
     "STANDALONEMONTH": [
       "Enero",

--- a/angular-locale_es-pr.js
+++ b/angular-locale_es-pr.js
@@ -51,7 +51,7 @@ $provide.value("$locale", {
     "SHORTMONTH": [
       "ene",
       "feb",
-      "mar.",
+      "mar",
       "abr",
       "may",
       "jun",

--- a/angular-locale_es-pr.js
+++ b/angular-locale_es-pr.js
@@ -40,27 +40,27 @@ $provide.value("$locale", {
       "diciembre"
     ],
     "SHORTDAY": [
-      "dom.",
-      "lun.",
-      "mar.",
-      "mi\u00e9.",
-      "jue.",
-      "vie.",
-      "s\u00e1b."
+      "dom",
+      "lun",
+      "mar",
+      "mi\u00e9",
+      "jue",
+      "vie",
+      "s\u00e1b"
     ],
     "SHORTMONTH": [
-      "ene.",
-      "feb.",
+      "ene",
+      "feb",
       "mar.",
-      "abr.",
-      "may.",
-      "jun.",
-      "jul.",
-      "ago.",
-      "sept.",
-      "oct.",
-      "nov.",
-      "dic."
+      "abr",
+      "may",
+      "jun",
+      "jul",
+      "ago",
+      "sep",
+      "oct",
+      "nov",
+      "dic"
     ],
     "STANDALONEMONTH": [
       "Enero",

--- a/angular-locale_es-py.js
+++ b/angular-locale_es-py.js
@@ -51,7 +51,7 @@ $provide.value("$locale", {
     "SHORTMONTH": [
       "ene",
       "feb",
-      "mar.",
+      "mar",
       "abr",
       "may",
       "jun",

--- a/angular-locale_es-py.js
+++ b/angular-locale_es-py.js
@@ -40,27 +40,27 @@ $provide.value("$locale", {
       "diciembre"
     ],
     "SHORTDAY": [
-      "dom.",
-      "lun.",
-      "mar.",
-      "mi\u00e9.",
-      "jue.",
-      "vie.",
-      "s\u00e1b."
+      "dom",
+      "lun",
+      "mar",
+      "mi\u00e9",
+      "jue",
+      "vie",
+      "s\u00e1b"
     ],
     "SHORTMONTH": [
-      "ene.",
-      "feb.",
+      "ene",
+      "feb",
       "mar.",
-      "abr.",
-      "may.",
-      "jun.",
-      "jul.",
-      "ago.",
-      "sept.",
-      "oct.",
-      "nov.",
-      "dic."
+      "abr",
+      "may",
+      "jun",
+      "jul",
+      "ago",
+      "sep",
+      "oct",
+      "nov",
+      "dic"
     ],
     "STANDALONEMONTH": [
       "Enero",

--- a/angular-locale_es-sv.js
+++ b/angular-locale_es-sv.js
@@ -51,7 +51,7 @@ $provide.value("$locale", {
     "SHORTMONTH": [
       "ene",
       "feb",
-      "mar.",
+      "mar",
       "abr",
       "may",
       "jun",

--- a/angular-locale_es-sv.js
+++ b/angular-locale_es-sv.js
@@ -40,27 +40,27 @@ $provide.value("$locale", {
       "diciembre"
     ],
     "SHORTDAY": [
-      "dom.",
-      "lun.",
-      "mar.",
-      "mi\u00e9.",
-      "jue.",
-      "vie.",
-      "s\u00e1b."
+      "dom",
+      "lun",
+      "mar",
+      "mi\u00e9",
+      "jue",
+      "vie",
+      "s\u00e1b"
     ],
     "SHORTMONTH": [
-      "ene.",
-      "feb.",
+      "ene",
+      "feb",
       "mar.",
-      "abr.",
-      "may.",
-      "jun.",
-      "jul.",
-      "ago.",
-      "sept.",
-      "oct.",
-      "nov.",
-      "dic."
+      "abr",
+      "may",
+      "jun",
+      "jul",
+      "ago",
+      "sep",
+      "oct",
+      "nov",
+      "dic"
     ],
     "STANDALONEMONTH": [
       "Enero",

--- a/angular-locale_es-us.js
+++ b/angular-locale_es-us.js
@@ -51,7 +51,7 @@ $provide.value("$locale", {
     "SHORTMONTH": [
       "ene",
       "feb",
-      "mar.",
+      "mar",
       "abr",
       "may",
       "jun",

--- a/angular-locale_es-us.js
+++ b/angular-locale_es-us.js
@@ -40,27 +40,27 @@ $provide.value("$locale", {
       "diciembre"
     ],
     "SHORTDAY": [
-      "dom.",
-      "lun.",
-      "mar.",
-      "mi\u00e9.",
-      "jue.",
-      "vie.",
-      "s\u00e1b."
+      "dom",
+      "lun",
+      "mar",
+      "mi\u00e9",
+      "jue",
+      "vie",
+      "s\u00e1b"
     ],
     "SHORTMONTH": [
-      "ene.",
-      "feb.",
+      "ene",
+      "feb",
       "mar.",
-      "abr.",
-      "may.",
-      "jun.",
-      "jul.",
-      "ago.",
-      "sept.",
-      "oct.",
-      "nov.",
-      "dic."
+      "abr",
+      "may",
+      "jun",
+      "jul",
+      "ago",
+      "sep",
+      "oct",
+      "nov",
+      "dic"
     ],
     "STANDALONEMONTH": [
       "Enero",

--- a/angular-locale_es-uy.js
+++ b/angular-locale_es-uy.js
@@ -40,27 +40,27 @@ $provide.value("$locale", {
       "diciembre"
     ],
     "SHORTDAY": [
-      "dom.",
-      "lun.",
-      "mar.",
-      "mi\u00e9.",
-      "jue.",
-      "vie.",
-      "s\u00e1b."
+      "dom",
+      "lun",
+      "mar",
+      "mi\u00e9",
+      "jue",
+      "vie",
+      "s\u00e1b"
     ],
     "SHORTMONTH": [
-      "ene.",
-      "feb.",
+      "ene",
+      "feb",
       "mar.",
-      "abr.",
-      "may.",
-      "jun.",
-      "jul.",
-      "ago.",
-      "set.",
-      "oct.",
-      "nov.",
-      "dic."
+      "abr",
+      "may",
+      "jun",
+      "jul",
+      "ago",
+      "sep",
+      "oct",
+      "nov",
+      "dic"
     ],
     "STANDALONEMONTH": [
       "Enero",

--- a/angular-locale_es-uy.js
+++ b/angular-locale_es-uy.js
@@ -51,7 +51,7 @@ $provide.value("$locale", {
     "SHORTMONTH": [
       "ene",
       "feb",
-      "mar.",
+      "mar",
       "abr",
       "may",
       "jun",

--- a/angular-locale_es-ve.js
+++ b/angular-locale_es-ve.js
@@ -51,7 +51,7 @@ $provide.value("$locale", {
     "SHORTMONTH": [
       "ene",
       "feb",
-      "mar.",
+      "mar",
       "abr",
       "may",
       "jun",

--- a/angular-locale_es-ve.js
+++ b/angular-locale_es-ve.js
@@ -40,27 +40,27 @@ $provide.value("$locale", {
       "diciembre"
     ],
     "SHORTDAY": [
-      "dom.",
-      "lun.",
-      "mar.",
-      "mi\u00e9.",
-      "jue.",
-      "vie.",
-      "s\u00e1b."
+      "dom",
+      "lun",
+      "mar",
+      "mi\u00e9",
+      "jue",
+      "vie",
+      "s\u00e1b"
     ],
     "SHORTMONTH": [
-      "ene.",
-      "feb.",
+      "ene",
+      "feb",
       "mar.",
-      "abr.",
-      "may.",
-      "jun.",
-      "jul.",
-      "ago.",
-      "sept.",
-      "oct.",
-      "nov.",
-      "dic."
+      "abr",
+      "may",
+      "jun",
+      "jul",
+      "ago",
+      "sep",
+      "oct",
+      "nov",
+      "dic"
     ],
     "STANDALONEMONTH": [
       "Enero",

--- a/angular-locale_es.js
+++ b/angular-locale_es.js
@@ -51,7 +51,7 @@ $provide.value("$locale", {
     "SHORTMONTH": [
       "ene",
       "feb",
-      "mar.",
+      "mar",
       "abr",
       "may",
       "jun",

--- a/angular-locale_es.js
+++ b/angular-locale_es.js
@@ -40,27 +40,27 @@ $provide.value("$locale", {
       "diciembre"
     ],
     "SHORTDAY": [
-      "dom.",
-      "lun.",
-      "mar.",
-      "mi\u00e9.",
-      "jue.",
-      "vie.",
-      "s\u00e1b."
+      "dom",
+      "lun",
+      "mar",
+      "mi\u00e9",
+      "jue",
+      "vie",
+      "s\u00e1b"
     ],
     "SHORTMONTH": [
-      "ene.",
-      "feb.",
+      "ene",
+      "feb",
       "mar.",
-      "abr.",
-      "may.",
-      "jun.",
-      "jul.",
-      "ago.",
-      "sept.",
-      "oct.",
-      "nov.",
-      "dic."
+      "abr",
+      "may",
+      "jun",
+      "jul",
+      "ago",
+      "sep",
+      "oct",
+      "nov",
+      "dic"
     ],
     "STANDALONEMONTH": [
       "Enero",


### PR DESCRIPTION
The language codes for months and days in Spanish translations are misspelled. They look like "ene.", "feb.", "lun.", "mar.", and so on, but in Spanish grammar that final point is not applied to date codes, just to abbreviations ("en.", "febr.", "lun.", "mart.", etc.). You can see that three letter without dot is the default everywhere.

http://www.fundeu.es/escribireninternet/abreviaturas-de-los-meses-y-los-dias-de-la-semana/

This must be changed in all "es-xx" JS files.
