### PR TITLE
First day of the week in Sweden is Monday

### DIFF
--- a/angular-locale_sv-se.js
+++ b/angular-locale_sv-se.js
@@ -42,7 +42,7 @@ $provide.value("$locale", {
       "f.Kr.",
       "e.Kr."
     ],
-    "FIRSTDAYOFWEEK": 0,
+    "FIRSTDAYOFWEEK": 1,
     "MONTH": [
       "januari",
       "februari",


### PR DESCRIPTION
Sweden adopted ISO 2711 in 1973.
