### PR TITLE
Sweden uses ISO 8601, which means that Monday is the first day of the week.

### DIFF
--- a/angular-locale_sv-ax.js
+++ b/angular-locale_sv-ax.js
@@ -42,7 +42,7 @@ $provide.value("$locale", {
       "f.Kr.",
       "e.Kr."
     ],
-    "FIRSTDAYOFWEEK": 0,
+    "FIRSTDAYOFWEEK": 1,
     "MONTH": [
       "januari",
       "februari",

--- a/angular-locale_sv-fi.js
+++ b/angular-locale_sv-fi.js
@@ -42,7 +42,7 @@ $provide.value("$locale", {
       "f.Kr.",
       "e.Kr."
     ],
-    "FIRSTDAYOFWEEK": 0,
+    "FIRSTDAYOFWEEK": 1,
     "MONTH": [
       "januari",
       "februari",

--- a/angular-locale_sv-se.js
+++ b/angular-locale_sv-se.js
@@ -42,7 +42,7 @@ $provide.value("$locale", {
       "f.Kr.",
       "e.Kr."
     ],
-    "FIRSTDAYOFWEEK": 0,
+    "FIRSTDAYOFWEEK": 1,
     "MONTH": [
       "januari",
       "februari",

--- a/angular-locale_sv.js
+++ b/angular-locale_sv.js
@@ -42,7 +42,7 @@ $provide.value("$locale", {
       "f.Kr.",
       "e.Kr."
     ],
-    "FIRSTDAYOFWEEK": 0,
+    "FIRSTDAYOFWEEK": 1,
     "MONTH": [
       "januari",
       "februari",


### PR DESCRIPTION
The change applies to sv, sv-se, sv-ax, and sv-fi in contrast to pull-request #22.
