### PR TITLE
Update angular-locale_fr-dz.js

### DIFF
--- a/angular-locale_fr-dz.js
+++ b/angular-locale_fr-dz.js
@@ -90,7 +90,7 @@ $provide.value("$locale", {
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "din",
+    "CURRENCY_SYM": "da",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": "\u00a0",
     "PATTERNS": [


### PR DESCRIPTION
Algeria's currency is not "din", it is "da".
