### PR TITLE
adding &rlm;(\u200f) to beginning of right to left date formats

### DIFF
--- a/angular-locale_ar-001.js
+++ b/angular-locale_ar-001.js
@@ -82,11 +82,11 @@ $provide.value("$locale", {
     ],
     "fullDate": "EEEE\u060c d MMMM\u060c y",
     "longDate": "d MMMM\u060c y",
-    "medium": "dd\u200f/MM\u200f/y h:mm:ss a",
-    "mediumDate": "dd\u200f/MM\u200f/y",
+    "medium": "\u200fdd\u200f/MM\u200f/y h:mm:ss a",
+    "mediumDate": "\u200fdd\u200f/MM\u200f/y",
     "mediumTime": "h:mm:ss a",
-    "short": "d\u200f/M\u200f/y h:mm a",
-    "shortDate": "d\u200f/M\u200f/y",
+    "short": "\u200fd\u200f/M\u200f/y h:mm a",
+    "shortDate": "\u200fd\u200f/M\u200f/y",
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {

--- a/angular-locale_ar-ae.js
+++ b/angular-locale_ar-ae.js
@@ -82,11 +82,11 @@ $provide.value("$locale", {
     ],
     "fullDate": "EEEE\u060c d MMMM\u060c y",
     "longDate": "d MMMM\u060c y",
-    "medium": "dd\u200f/MM\u200f/y h:mm:ss a",
-    "mediumDate": "dd\u200f/MM\u200f/y",
+    "medium": "\u200fdd\u200f/MM\u200f/y h:mm:ss a",
+    "mediumDate": "\u200fdd\u200f/MM\u200f/y",
     "mediumTime": "h:mm:ss a",
-    "short": "d\u200f/M\u200f/y h:mm a",
-    "shortDate": "d\u200f/M\u200f/y",
+    "short": "\u200fd\u200f/M\u200f/y h:mm a",
+    "shortDate": "\u200fd\u200f/M\u200f/y",
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {

--- a/angular-locale_ar-bh.js
+++ b/angular-locale_ar-bh.js
@@ -82,11 +82,11 @@ $provide.value("$locale", {
     ],
     "fullDate": "EEEE\u060c d MMMM\u060c y",
     "longDate": "d MMMM\u060c y",
-    "medium": "dd\u200f/MM\u200f/y h:mm:ss a",
-    "mediumDate": "dd\u200f/MM\u200f/y",
+    "medium": "\u200fdd\u200f/MM\u200f/y h:mm:ss a",
+    "mediumDate": "\u200fdd\u200f/MM\u200f/y",
     "mediumTime": "h:mm:ss a",
-    "short": "d\u200f/M\u200f/y h:mm a",
-    "shortDate": "d\u200f/M\u200f/y",
+    "short": "\u200fd\u200f/M\u200f/y h:mm a",
+    "shortDate": "\u200fd\u200f/M\u200f/y",
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {

--- a/angular-locale_ar-dj.js
+++ b/angular-locale_ar-dj.js
@@ -82,11 +82,11 @@ $provide.value("$locale", {
     ],
     "fullDate": "EEEE\u060c d MMMM\u060c y",
     "longDate": "d MMMM\u060c y",
-    "medium": "dd\u200f/MM\u200f/y h:mm:ss a",
-    "mediumDate": "dd\u200f/MM\u200f/y",
+    "medium": "\u200fdd\u200f/MM\u200f/y h:mm:ss a",
+    "mediumDate": "\u200fdd\u200f/MM\u200f/y",
     "mediumTime": "h:mm:ss a",
-    "short": "d\u200f/M\u200f/y h:mm a",
-    "shortDate": "d\u200f/M\u200f/y",
+    "short": "\u200fd\u200f/M\u200f/y h:mm a",
+    "shortDate": "\u200fd\u200f/M\u200f/y",
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {

--- a/angular-locale_ar-dz.js
+++ b/angular-locale_ar-dz.js
@@ -82,11 +82,11 @@ $provide.value("$locale", {
     ],
     "fullDate": "EEEE\u060c d MMMM\u060c y",
     "longDate": "d MMMM\u060c y",
-    "medium": "dd\u200f/MM\u200f/y h:mm:ss a",
-    "mediumDate": "dd\u200f/MM\u200f/y",
+    "medium": "\u200fdd\u200f/MM\u200f/y h:mm:ss a",
+    "mediumDate": "\u200fdd\u200f/MM\u200f/y",
     "mediumTime": "h:mm:ss a",
-    "short": "d\u200f/M\u200f/y h:mm a",
-    "shortDate": "d\u200f/M\u200f/y",
+    "short": "\u200fd\u200f/M\u200f/y h:mm a",
+    "shortDate": "\u200fd\u200f/M\u200f/y",
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {

--- a/angular-locale_ar-eg.js
+++ b/angular-locale_ar-eg.js
@@ -82,11 +82,11 @@ $provide.value("$locale", {
     ],
     "fullDate": "EEEE\u060c d MMMM\u060c y",
     "longDate": "d MMMM\u060c y",
-    "medium": "dd\u200f/MM\u200f/y h:mm:ss a",
-    "mediumDate": "dd\u200f/MM\u200f/y",
+    "medium": "\u200fdd\u200f/MM\u200f/y h:mm:ss a",
+    "mediumDate": "\u200fdd\u200f/MM\u200f/y",
     "mediumTime": "h:mm:ss a",
-    "short": "d\u200f/M\u200f/y h:mm a",
-    "shortDate": "d\u200f/M\u200f/y",
+    "short": "\u200fd\u200f/M\u200f/y h:mm a",
+    "shortDate": "\u200fd\u200f/M\u200f/y",
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {

--- a/angular-locale_ar-eh.js
+++ b/angular-locale_ar-eh.js
@@ -82,11 +82,11 @@ $provide.value("$locale", {
     ],
     "fullDate": "EEEE\u060c d MMMM\u060c y",
     "longDate": "d MMMM\u060c y",
-    "medium": "dd\u200f/MM\u200f/y h:mm:ss a",
-    "mediumDate": "dd\u200f/MM\u200f/y",
+    "medium": "\u200fdd\u200f/MM\u200f/y h:mm:ss a",
+    "mediumDate": "\u200fdd\u200f/MM\u200f/y",
     "mediumTime": "h:mm:ss a",
-    "short": "d\u200f/M\u200f/y h:mm a",
-    "shortDate": "d\u200f/M\u200f/y",
+    "short": "\u200fd\u200f/M\u200f/y h:mm a",
+    "shortDate": "\u200fd\u200f/M\u200f/y",
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {

--- a/angular-locale_ar-er.js
+++ b/angular-locale_ar-er.js
@@ -82,11 +82,11 @@ $provide.value("$locale", {
     ],
     "fullDate": "EEEE\u060c d MMMM\u060c y",
     "longDate": "d MMMM\u060c y",
-    "medium": "dd\u200f/MM\u200f/y h:mm:ss a",
-    "mediumDate": "dd\u200f/MM\u200f/y",
+    "medium": "\u200fdd\u200f/MM\u200f/y h:mm:ss a",
+    "mediumDate": "\u200fdd\u200f/MM\u200f/y",
     "mediumTime": "h:mm:ss a",
-    "short": "d\u200f/M\u200f/y h:mm a",
-    "shortDate": "d\u200f/M\u200f/y",
+    "short": "\u200fd\u200f/M\u200f/y h:mm a",
+    "shortDate": "\u200fd\u200f/M\u200f/y",
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {

--- a/angular-locale_ar-il.js
+++ b/angular-locale_ar-il.js
@@ -83,10 +83,10 @@ $provide.value("$locale", {
     "fullDate": "EEEE\u060c d MMMM\u060c y",
     "longDate": "d MMMM\u060c y",
     "medium": "dd\u200f/MM\u200f/y H:mm:ss",
-    "mediumDate": "dd\u200f/MM\u200f/y",
+    "mediumDate": "\u200fdd\u200f/MM\u200f/y",
     "mediumTime": "H:mm:ss",
     "short": "d\u200f/M\u200f/y H:mm",
-    "shortDate": "d\u200f/M\u200f/y",
+    "shortDate": "\u200fd\u200f/M\u200f/y",
     "shortTime": "H:mm"
   },
   "NUMBER_FORMATS": {

--- a/angular-locale_ar-iq.js
+++ b/angular-locale_ar-iq.js
@@ -82,11 +82,11 @@ $provide.value("$locale", {
     ],
     "fullDate": "EEEE\u060c d MMMM\u060c y",
     "longDate": "d MMMM\u060c y",
-    "medium": "dd\u200f/MM\u200f/y h:mm:ss a",
-    "mediumDate": "dd\u200f/MM\u200f/y",
+    "medium": "\u200fdd\u200f/MM\u200f/y h:mm:ss a",
+    "mediumDate": "\u200fdd\u200f/MM\u200f/y",
     "mediumTime": "h:mm:ss a",
-    "short": "d\u200f/M\u200f/y h:mm a",
-    "shortDate": "d\u200f/M\u200f/y",
+    "short": "\u200fd\u200f/M\u200f/y h:mm a",
+    "shortDate": "\u200fd\u200f/M\u200f/y",
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {

--- a/angular-locale_ar-jo.js
+++ b/angular-locale_ar-jo.js
@@ -82,11 +82,11 @@ $provide.value("$locale", {
     ],
     "fullDate": "EEEE\u060c d MMMM\u060c y",
     "longDate": "d MMMM\u060c y",
-    "medium": "dd\u200f/MM\u200f/y h:mm:ss a",
-    "mediumDate": "dd\u200f/MM\u200f/y",
+    "medium": "\u200fdd\u200f/MM\u200f/y h:mm:ss a",
+    "mediumDate": "\u200fdd\u200f/MM\u200f/y",
     "mediumTime": "h:mm:ss a",
-    "short": "d\u200f/M\u200f/y h:mm a",
-    "shortDate": "d\u200f/M\u200f/y",
+    "short": "\u200fd\u200f/M\u200f/y h:mm a",
+    "shortDate": "\u200fd\u200f/M\u200f/y",
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {

--- a/angular-locale_ar-km.js
+++ b/angular-locale_ar-km.js
@@ -83,10 +83,10 @@ $provide.value("$locale", {
     "fullDate": "EEEE\u060c d MMMM\u060c y",
     "longDate": "d MMMM\u060c y",
     "medium": "dd\u200f/MM\u200f/y HH:mm:ss",
-    "mediumDate": "dd\u200f/MM\u200f/y",
+    "mediumDate": "\u200fdd\u200f/MM\u200f/y",
     "mediumTime": "HH:mm:ss",
     "short": "d\u200f/M\u200f/y HH:mm",
-    "shortDate": "d\u200f/M\u200f/y",
+    "shortDate": "\u200fd\u200f/M\u200f/y",
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {

--- a/angular-locale_ar-kw.js
+++ b/angular-locale_ar-kw.js
@@ -82,11 +82,11 @@ $provide.value("$locale", {
     ],
     "fullDate": "EEEE\u060c d MMMM\u060c y",
     "longDate": "d MMMM\u060c y",
-    "medium": "dd\u200f/MM\u200f/y h:mm:ss a",
-    "mediumDate": "dd\u200f/MM\u200f/y",
+    "medium": "\u200fdd\u200f/MM\u200f/y h:mm:ss a",
+    "mediumDate": "\u200fdd\u200f/MM\u200f/y",
     "mediumTime": "h:mm:ss a",
-    "short": "d\u200f/M\u200f/y h:mm a",
-    "shortDate": "d\u200f/M\u200f/y",
+    "short": "\u200fd\u200f/M\u200f/y h:mm a",
+    "shortDate": "\u200fd\u200f/M\u200f/y",
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {

--- a/angular-locale_ar-lb.js
+++ b/angular-locale_ar-lb.js
@@ -82,11 +82,11 @@ $provide.value("$locale", {
     ],
     "fullDate": "EEEE\u060c d MMMM\u060c y",
     "longDate": "d MMMM\u060c y",
-    "medium": "dd\u200f/MM\u200f/y h:mm:ss a",
-    "mediumDate": "dd\u200f/MM\u200f/y",
+    "medium": "\u200fdd\u200f/MM\u200f/y h:mm:ss a",
+    "mediumDate": "\u200fdd\u200f/MM\u200f/y",
     "mediumTime": "h:mm:ss a",
-    "short": "d\u200f/M\u200f/y h:mm a",
-    "shortDate": "d\u200f/M\u200f/y",
+    "short": "\u200fd\u200f/M\u200f/y h:mm a",
+    "shortDate": "\u200fd\u200f/M\u200f/y",
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {

--- a/angular-locale_ar-ly.js
+++ b/angular-locale_ar-ly.js
@@ -82,11 +82,11 @@ $provide.value("$locale", {
     ],
     "fullDate": "EEEE\u060c d MMMM\u060c y",
     "longDate": "d MMMM\u060c y",
-    "medium": "dd\u200f/MM\u200f/y h:mm:ss a",
-    "mediumDate": "dd\u200f/MM\u200f/y",
+    "medium": "\u200fdd\u200f/MM\u200f/y h:mm:ss a",
+    "mediumDate": "\u200fdd\u200f/MM\u200f/y",
     "mediumTime": "h:mm:ss a",
-    "short": "d\u200f/M\u200f/y h:mm a",
-    "shortDate": "d\u200f/M\u200f/y",
+    "short": "\u200fd\u200f/M\u200f/y h:mm a",
+    "shortDate": "\u200fd\u200f/M\u200f/y",
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {

--- a/angular-locale_ar-ma.js
+++ b/angular-locale_ar-ma.js
@@ -83,10 +83,10 @@ $provide.value("$locale", {
     "fullDate": "EEEE\u060c d MMMM\u060c y",
     "longDate": "d MMMM\u060c y",
     "medium": "dd\u200f/MM\u200f/y HH:mm:ss",
-    "mediumDate": "dd\u200f/MM\u200f/y",
+    "mediumDate": "\u200fdd\u200f/MM\u200f/y",
     "mediumTime": "HH:mm:ss",
     "short": "d\u200f/M\u200f/y HH:mm",
-    "shortDate": "d\u200f/M\u200f/y",
+    "shortDate": "\u200fd\u200f/M\u200f/y",
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {

--- a/angular-locale_ar-mr.js
+++ b/angular-locale_ar-mr.js
@@ -82,11 +82,11 @@ $provide.value("$locale", {
     ],
     "fullDate": "EEEE\u060c d MMMM\u060c y",
     "longDate": "d MMMM\u060c y",
-    "medium": "dd\u200f/MM\u200f/y h:mm:ss a",
-    "mediumDate": "dd\u200f/MM\u200f/y",
+    "medium": "\u200fdd\u200f/MM\u200f/y h:mm:ss a",
+    "mediumDate": "\u200fdd\u200f/MM\u200f/y",
     "mediumTime": "h:mm:ss a",
-    "short": "d\u200f/M\u200f/y h:mm a",
-    "shortDate": "d\u200f/M\u200f/y",
+    "short": "\u200fd\u200f/M\u200f/y h:mm a",
+    "shortDate": "\u200fd\u200f/M\u200f/y",
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {

--- a/angular-locale_ar-om.js
+++ b/angular-locale_ar-om.js
@@ -82,11 +82,11 @@ $provide.value("$locale", {
     ],
     "fullDate": "EEEE\u060c d MMMM\u060c y",
     "longDate": "d MMMM\u060c y",
-    "medium": "dd\u200f/MM\u200f/y h:mm:ss a",
-    "mediumDate": "dd\u200f/MM\u200f/y",
+    "medium": "\u200fdd\u200f/MM\u200f/y h:mm:ss a",
+    "mediumDate": "\u200fdd\u200f/MM\u200f/y",
     "mediumTime": "h:mm:ss a",
-    "short": "d\u200f/M\u200f/y h:mm a",
-    "shortDate": "d\u200f/M\u200f/y",
+    "short": "\u200fd\u200f/M\u200f/y h:mm a",
+    "shortDate": "\u200fd\u200f/M\u200f/y",
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {

--- a/angular-locale_ar-ps.js
+++ b/angular-locale_ar-ps.js
@@ -82,11 +82,11 @@ $provide.value("$locale", {
     ],
     "fullDate": "EEEE\u060c d MMMM\u060c y",
     "longDate": "d MMMM\u060c y",
-    "medium": "dd\u200f/MM\u200f/y h:mm:ss a",
-    "mediumDate": "dd\u200f/MM\u200f/y",
+    "medium": "\u200fdd\u200f/MM\u200f/y h:mm:ss a",
+    "mediumDate": "\u200fdd\u200f/MM\u200f/y",
     "mediumTime": "h:mm:ss a",
-    "short": "d\u200f/M\u200f/y h:mm a",
-    "shortDate": "d\u200f/M\u200f/y",
+    "short": "\u200fd\u200f/M\u200f/y h:mm a",
+    "shortDate": "\u200fd\u200f/M\u200f/y",
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {

--- a/angular-locale_ar-qa.js
+++ b/angular-locale_ar-qa.js
@@ -82,11 +82,11 @@ $provide.value("$locale", {
     ],
     "fullDate": "EEEE\u060c d MMMM\u060c y",
     "longDate": "d MMMM\u060c y",
-    "medium": "dd\u200f/MM\u200f/y h:mm:ss a",
-    "mediumDate": "dd\u200f/MM\u200f/y",
+    "medium": "\u200fdd\u200f/MM\u200f/y h:mm:ss a",
+    "mediumDate": "\u200fdd\u200f/MM\u200f/y",
     "mediumTime": "h:mm:ss a",
-    "short": "d\u200f/M\u200f/y h:mm a",
-    "shortDate": "d\u200f/M\u200f/y",
+    "short": "\u200fd\u200f/M\u200f/y h:mm a",
+    "shortDate": "\u200fd\u200f/M\u200f/y",
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {

--- a/angular-locale_ar-sa.js
+++ b/angular-locale_ar-sa.js
@@ -82,11 +82,11 @@ $provide.value("$locale", {
     ],
     "fullDate": "EEEE\u060c d MMMM\u060c y",
     "longDate": "d MMMM\u060c y",
-    "medium": "dd\u200f/MM\u200f/y h:mm:ss a",
-    "mediumDate": "dd\u200f/MM\u200f/y",
+    "medium": "\u200fdd\u200f/MM\u200f/y h:mm:ss a",
+    "mediumDate": "\u200fdd\u200f/MM\u200f/y",
     "mediumTime": "h:mm:ss a",
-    "short": "d\u200f/M\u200f/y h:mm a",
-    "shortDate": "d\u200f/M\u200f/y",
+    "short": "\u200fd\u200f/M\u200f/y h:mm a",
+    "shortDate": "\u200fd\u200f/M\u200f/y",
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {

--- a/angular-locale_ar-sd.js
+++ b/angular-locale_ar-sd.js
@@ -82,11 +82,11 @@ $provide.value("$locale", {
     ],
     "fullDate": "EEEE\u060c d MMMM\u060c y",
     "longDate": "d MMMM\u060c y",
-    "medium": "dd\u200f/MM\u200f/y h:mm:ss a",
-    "mediumDate": "dd\u200f/MM\u200f/y",
+    "medium": "\u200fdd\u200f/MM\u200f/y h:mm:ss a",
+    "mediumDate": "\u200fdd\u200f/MM\u200f/y",
     "mediumTime": "h:mm:ss a",
-    "short": "d\u200f/M\u200f/y h:mm a",
-    "shortDate": "d\u200f/M\u200f/y",
+    "short": "\u200fd\u200f/M\u200f/y h:mm a",
+    "shortDate": "\u200fd\u200f/M\u200f/y",
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {

--- a/angular-locale_ar-so.js
+++ b/angular-locale_ar-so.js
@@ -82,11 +82,11 @@ $provide.value("$locale", {
     ],
     "fullDate": "EEEE\u060c d MMMM\u060c y",
     "longDate": "d MMMM\u060c y",
-    "medium": "dd\u200f/MM\u200f/y h:mm:ss a",
-    "mediumDate": "dd\u200f/MM\u200f/y",
+    "medium": "\u200fdd\u200f/MM\u200f/y h:mm:ss a",
+    "mediumDate": "\u200fdd\u200f/MM\u200f/y",
     "mediumTime": "h:mm:ss a",
-    "short": "d\u200f/M\u200f/y h:mm a",
-    "shortDate": "d\u200f/M\u200f/y",
+    "short": "\u200fd\u200f/M\u200f/y h:mm a",
+    "shortDate": "\u200fd\u200f/M\u200f/y",
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {

--- a/angular-locale_ar-ss.js
+++ b/angular-locale_ar-ss.js
@@ -82,11 +82,11 @@ $provide.value("$locale", {
     ],
     "fullDate": "EEEE\u060c d MMMM\u060c y",
     "longDate": "d MMMM\u060c y",
-    "medium": "dd\u200f/MM\u200f/y h:mm:ss a",
-    "mediumDate": "dd\u200f/MM\u200f/y",
+    "medium": "\u200fdd\u200f/MM\u200f/y h:mm:ss a",
+    "mediumDate": "\u200fdd\u200f/MM\u200f/y",
     "mediumTime": "h:mm:ss a",
-    "short": "d\u200f/M\u200f/y h:mm a",
-    "shortDate": "d\u200f/M\u200f/y",
+    "short": "\u200fd\u200f/M\u200f/y h:mm a",
+    "shortDate": "\u200fd\u200f/M\u200f/y",
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {

--- a/angular-locale_ar-sy.js
+++ b/angular-locale_ar-sy.js
@@ -82,11 +82,11 @@ $provide.value("$locale", {
     ],
     "fullDate": "EEEE\u060c d MMMM\u060c y",
     "longDate": "d MMMM\u060c y",
-    "medium": "dd\u200f/MM\u200f/y h:mm:ss a",
-    "mediumDate": "dd\u200f/MM\u200f/y",
+    "medium": "\u200fdd\u200f/MM\u200f/y h:mm:ss a",
+    "mediumDate": "\u200fdd\u200f/MM\u200f/y",
     "mediumTime": "h:mm:ss a",
-    "short": "d\u200f/M\u200f/y h:mm a",
-    "shortDate": "d\u200f/M\u200f/y",
+    "short": "\u200fd\u200f/M\u200f/y h:mm a",
+    "shortDate": "\u200fd\u200f/M\u200f/y",
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {

--- a/angular-locale_ar-td.js
+++ b/angular-locale_ar-td.js
@@ -82,11 +82,11 @@ $provide.value("$locale", {
     ],
     "fullDate": "EEEE\u060c d MMMM\u060c y",
     "longDate": "d MMMM\u060c y",
-    "medium": "dd\u200f/MM\u200f/y h:mm:ss a",
-    "mediumDate": "dd\u200f/MM\u200f/y",
+    "medium": "\u200fdd\u200f/MM\u200f/y h:mm:ss a",
+    "mediumDate": "\u200fdd\u200f/MM\u200f/y",
     "mediumTime": "h:mm:ss a",
-    "short": "d\u200f/M\u200f/y h:mm a",
-    "shortDate": "d\u200f/M\u200f/y",
+    "short": "\u200fd\u200f/M\u200f/y h:mm a",
+    "shortDate": "\u200fd\u200f/M\u200f/y",
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {

--- a/angular-locale_ar-tn.js
+++ b/angular-locale_ar-tn.js
@@ -82,11 +82,11 @@ $provide.value("$locale", {
     ],
     "fullDate": "EEEE\u060c d MMMM\u060c y",
     "longDate": "d MMMM\u060c y",
-    "medium": "dd\u200f/MM\u200f/y h:mm:ss a",
-    "mediumDate": "dd\u200f/MM\u200f/y",
+    "medium": "\u200fdd\u200f/MM\u200f/y h:mm:ss a",
+    "mediumDate": "\u200fdd\u200f/MM\u200f/y",
     "mediumTime": "h:mm:ss a",
-    "short": "d\u200f/M\u200f/y h:mm a",
-    "shortDate": "d\u200f/M\u200f/y",
+    "short": "\u200fd\u200f/M\u200f/y h:mm a",
+    "shortDate": "\u200fd\u200f/M\u200f/y",
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {

--- a/angular-locale_ar-xb.js
+++ b/angular-locale_ar-xb.js
@@ -82,11 +82,11 @@ $provide.value("$locale", {
     ],
     "fullDate": "EEEE\u060c d MMMM\u060c y",
     "longDate": "d MMMM\u060c y",
-    "medium": "dd\u200f/MM\u200f/y h:mm:ss a",
-    "mediumDate": "dd\u200f/MM\u200f/y",
+    "medium": "\u200fdd\u200f/MM\u200f/y h:mm:ss a",
+    "mediumDate": "\u200fdd\u200f/MM\u200f/y",
     "mediumTime": "h:mm:ss a",
-    "short": "d\u200f/M\u200f/y h:mm a",
-    "shortDate": "d\u200f/M\u200f/y",
+    "short": "\u200fd\u200f/M\u200f/y h:mm a",
+    "shortDate": "\u200fd\u200f/M\u200f/y",
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {

--- a/angular-locale_ar-ye.js
+++ b/angular-locale_ar-ye.js
@@ -82,11 +82,11 @@ $provide.value("$locale", {
     ],
     "fullDate": "EEEE\u060c d MMMM\u060c y",
     "longDate": "d MMMM\u060c y",
-    "medium": "dd\u200f/MM\u200f/y h:mm:ss a",
-    "mediumDate": "dd\u200f/MM\u200f/y",
+    "medium": "\u200fdd\u200f/MM\u200f/y h:mm:ss a",
+    "mediumDate": "\u200fdd\u200f/MM\u200f/y",
     "mediumTime": "h:mm:ss a",
-    "short": "d\u200f/M\u200f/y h:mm a",
-    "shortDate": "d\u200f/M\u200f/y",
+    "short": "\u200fd\u200f/M\u200f/y h:mm a",
+    "shortDate": "\u200fd\u200f/M\u200f/y",
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {

--- a/angular-locale_ar.js
+++ b/angular-locale_ar.js
@@ -82,11 +82,11 @@ $provide.value("$locale", {
     ],
     "fullDate": "EEEE\u060c d MMMM\u060c y",
     "longDate": "d MMMM\u060c y",
-    "medium": "dd\u200f/MM\u200f/y h:mm:ss a",
-    "mediumDate": "dd\u200f/MM\u200f/y",
+    "medium": "\u200fdd\u200f/MM\u200f/y h:mm:ss a",
+    "mediumDate": "\u200fdd\u200f/MM\u200f/y",
     "mediumTime": "h:mm:ss a",
-    "short": "d\u200f/M\u200f/y h:mm a",
-    "shortDate": "d\u200f/M\u200f/y",
+    "short": "\u200fd\u200f/M\u200f/y h:mm a",
+    "shortDate": "\u200fd\u200f/M\u200f/y",
     "shortTime": "h:mm a"
   },
   "NUMBER_FORMATS": {


### PR DESCRIPTION
The first number/element in a date format wasn't being right-to-left'ed.

e.g. **en-US** -> 5/25/2017 was **ar-SA** -> 52017/25/