### PR TITLE
Changed currency symbol

### DIFF
--- a/angular-locale_tr.js
+++ b/angular-locale_tr.js
@@ -90,7 +90,7 @@ $provide.value("$locale", {
     "shortTime": "HH:mm"
   },
   "NUMBER_FORMATS": {
-    "CURRENCY_SYM": "TL",
+    "CURRENCY_SYM": "₺",
     "DECIMAL_SEP": ",",
     "GROUP_SEP": ".",
     "PATTERNS": [


### PR DESCRIPTION
Changed currency symbol from TL into ₺
This will represent Turkish Lira better than current TL text.