### PR TITLE
fix(ca): shortmonth corrected

### DIFF
--- a/angular-locale_ca-ad.js
+++ b/angular-locale_ca-ad.js
@@ -67,18 +67,18 @@ $provide.value("$locale", {
       "ds."
     ],
     "SHORTMONTH": [
-      "de gen.",
-      "de febr.",
-      "de mar\u00e7",
-      "d\u2019abr.",
-      "de maig",
-      "de juny",
-      "de jul.",
-      "d\u2019ag.",
-      "de set.",
-      "d\u2019oct.",
-      "de nov.",
-      "de des."
+      "gen.",
+      "febr.",
+      "mar\u00e7",
+      "abr.",
+      "maig",
+      "juny",
+      "jul.",
+      "ag.",
+      "set.",
+      "oct.",
+      "nov.",
+      "des."
     ],
     "STANDALONEMONTH": [
       "gener",

--- a/angular-locale_ca-es.js
+++ b/angular-locale_ca-es.js
@@ -67,18 +67,18 @@ $provide.value("$locale", {
       "ds."
     ],
     "SHORTMONTH": [
-      "de gen.",
-      "de febr.",
-      "de mar\u00e7",
-      "d\u2019abr.",
-      "de maig",
-      "de juny",
-      "de jul.",
-      "d\u2019ag.",
-      "de set.",
-      "d\u2019oct.",
-      "de nov.",
-      "de des."
+      "gen.",
+      "febr.",
+      "mar\u00e7",
+      "abr.",
+      "maig",
+      "juny",
+      "jul.",
+      "ag.",
+      "set.",
+      "oct.",
+      "nov.",
+      "des."
     ],
     "STANDALONEMONTH": [
       "gener",

--- a/angular-locale_ca-fr.js
+++ b/angular-locale_ca-fr.js
@@ -67,18 +67,18 @@ $provide.value("$locale", {
       "ds."
     ],
     "SHORTMONTH": [
-      "de gen.",
-      "de febr.",
-      "de mar\u00e7",
-      "d\u2019abr.",
-      "de maig",
-      "de juny",
-      "de jul.",
-      "d\u2019ag.",
-      "de set.",
-      "d\u2019oct.",
-      "de nov.",
-      "de des."
+      "gen.",
+      "febr.",
+      "mar\u00e7",
+      "abr.",
+      "maig",
+      "juny",
+      "jul.",
+      "ag.",
+      "set.",
+      "oct.",
+      "nov.",
+      "des."
     ],
     "STANDALONEMONTH": [
       "gener",

--- a/angular-locale_ca-it.js
+++ b/angular-locale_ca-it.js
@@ -67,18 +67,18 @@ $provide.value("$locale", {
       "ds."
     ],
     "SHORTMONTH": [
-      "de gen.",
-      "de febr.",
-      "de mar\u00e7",
-      "d\u2019abr.",
-      "de maig",
-      "de juny",
-      "de jul.",
-      "d\u2019ag.",
-      "de set.",
-      "d\u2019oct.",
-      "de nov.",
-      "de des."
+      "gen.",
+      "febr.",
+      "mar\u00e7",
+      "abr.",
+      "maig",
+      "juny",
+      "jul.",
+      "ag.",
+      "set.",
+      "oct.",
+      "nov.",
+      "des."
     ],
     "STANDALONEMONTH": [
       "gener",

--- a/angular-locale_ca.js
+++ b/angular-locale_ca.js
@@ -67,18 +67,18 @@ $provide.value("$locale", {
       "ds."
     ],
     "SHORTMONTH": [
-      "de gen.",
-      "de febr.",
-      "de mar\u00e7",
-      "d\u2019abr.",
-      "de maig",
-      "de juny",
-      "de jul.",
-      "d\u2019ag.",
-      "de set.",
-      "d\u2019oct.",
-      "de nov.",
-      "de des."
+      "gen.",
+      "febr.",
+      "mar\u00e7",
+      "abr.",
+      "maig",
+      "juny",
+      "jul.",
+      "ag.",
+      "set.",
+      "oct.",
+      "nov.",
+      "des."
     ],
     "STANDALONEMONTH": [
       "gener",


### PR DESCRIPTION
According to the Catalan language rules (http://aplicacions.llengua.gencat.cat/llc/AppJava/index.html?action=Principal&method=detall&input_cercar=abreviatures+mesos&numPagina=1&database=FITXES_PUB&idFont=8402&idHit=8402&tipusFont=Fitxes+de+l%27Optimot&numeroResultat=1&databases_avansada=&categories_avansada=&clickLink=detall&titol=abreviatures+dels+mesos+de+l%27any&tematica=&tipusCerca=cerca.normes) the shortmonths in catalan should not be prefixed with the article